### PR TITLE
Configure k8s prod deployment (nuxl-app) and drop arm64 from CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -103,15 +103,15 @@ jobs:
 
       - name: Retag for kind (image name the kustomize overlay points at)
         run: |
-          # The prod overlay sets `newName: ghcr.io/openms/streamlit-template`,
+          # The prod overlay sets `newName: ghcr.io/openms/nuxl-app`,
           # `newTag: main-full`. The rendered manifests reference that exact
           # ref, so we need it loaded into kind under that name. Tag invariant
           # across branches/variants so the test always works.
           FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" ghcr.io/openms/streamlit-template:main-full
+          docker tag "$FIRST_TAG" ghcr.io/openms/nuxl-app:main-full
 
       - name: Save image as tar
-        run: docker save ghcr.io/openms/streamlit-template:main-full -o /tmp/image.tar
+        run: docker save ghcr.io/openms/nuxl-app:main-full -o /tmp/image.tar
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4
@@ -197,15 +197,15 @@ jobs:
 
       - name: Retag for kind (image name the kustomize overlay points at)
         run: |
-          # The prod overlay sets `newName: ghcr.io/openms/streamlit-template`,
+          # The prod overlay sets `newName: ghcr.io/openms/nuxl-app`,
           # `newTag: main-full`. The rendered manifests reference that exact
           # ref, so we need it loaded into kind under that name. Tag invariant
           # across branches/variants so the test always works.
           FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" ghcr.io/openms/streamlit-template:main-full
+          docker tag "$FIRST_TAG" ghcr.io/openms/nuxl-app:main-full
 
       - name: Save image as tar
-        run: docker save ghcr.io/openms/streamlit-template:main-full -o /tmp/image.tar
+        run: docker save ghcr.io/openms/nuxl-app:main-full -o /tmp/image.tar
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,9 +39,9 @@ jobs:
             kubeconform -summary -strict -kubernetes-version 1.28.0 -skip IngressRoute
 
   build-amd64:
-    # amd64 path. Produces per-arch tags `<ref>-<variant>-amd64`; the
-    # multi-arch manifest under `<ref>-<variant>` (and `latest`) is stitched
-    # together in `create-manifest` once the sibling `build-arm64` succeeds.
+    # amd64-only build. Publishes the canonical tags directly
+    # (`<ref>-<variant>` and, on main, `latest`) — no per-arch suffix and no
+    # multi-arch manifest step, since arm64 is not built.
     needs: lint-manifests
     runs-on: ubuntu-latest
     permissions:
@@ -76,10 +76,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch,suffix=-${{ matrix.variant }}-amd64
-            type=ref,event=tag,suffix=-${{ matrix.variant }}-amd64
-            type=sha,prefix=,suffix=-${{ matrix.variant }}-amd64
-            type=raw,value=latest-amd64,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+            type=ref,event=branch,suffix=-${{ matrix.variant }}
+            type=ref,event=tag,suffix=-${{ matrix.variant }}
+            type=sha,prefix=,suffix=-${{ matrix.variant }}
+            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Build and conditionally push
         uses: docker/build-push-action@v5
@@ -91,10 +91,9 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          # provenance/attestations turn the pushed tag into a manifest list,
-          # which the create-manifest job's `docker manifest create` then
-          # refuses ("is a manifest list"). Keep the push as a single-platform
-          # image manifest — same as the build-arm64 job.
+          # Keep the push as a single-platform image manifest (not a
+          # manifest-list/index) so the `docker save` + `kind load` flow below
+          # works and consumers pull a plain amd64 image.
           provenance: false
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}-amd64
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2}-amd64,mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
@@ -119,162 +118,6 @@ jobs:
           name: openms-streamlit-${{ matrix.variant }}-amd64-image
           path: /tmp/image.tar
           retention-days: 1
-
-  build-arm64:
-    # arm64 path. Runs on a native ARM64 runner (no QEMU). Produces per-arch
-    # tags `<ref>-<variant>-arm64`; gets merged into the multi-arch manifest
-    # under `<ref>-<variant>` by the `create-manifest` job below. The build
-    # uses a separate `Dockerfile.arm` that swaps
-    # the miniforge installer to aarch64 and (for the full variant) guards
-    # the THIRDPARTY/Linux/aarch64 copy. The built image is also uploaded as
-    # an artifact so the apptainer / nginx / traefik integration jobs can
-    # exercise the ARM image on a native ARM runner (matrix arch=arm64).
-    needs: lint-manifests
-    runs-on: ubuntu-24.04-arm
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - variant: full
-            dockerfile: Dockerfile.arm
-    steps:
-      - name: Free disk space
-        # OpenMS source build needs ~25 GB of scratch space; the ARM runner
-        # image is tighter than the AMD one out of the box. Mirrors what
-        # FLASHApp's publish-docker-images.yml does at the top of its ARM job.
-        run: |
-          # Keep /opt/hostedtoolcache: helm/kind-action and setup-kubectl
-          # cache binaries there and fail if the directory is missing.
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc || true
-          sudo apt-get clean
-          df -h
-
-      - uses: actions/checkout@v4
-
-      - name: Compute lowercase image name (OCI refs must be lowercase)
-        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels)
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch,suffix=-${{ matrix.variant }}-arm64
-            type=ref,event=tag,suffix=-${{ matrix.variant }}-arm64
-            type=sha,prefix=,suffix=-${{ matrix.variant }}-arm64
-            type=raw,value=latest-arm64,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
-      - name: Build and conditionally push
-        uses: docker/build-push-action@v5
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/arm64
-          load: true
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}/cache:${{ matrix.variant }}-arm64
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}/cache:{2}-arm64,mode=max', env.REGISTRY, env.IMAGE_NAME_LC, matrix.variant) || '' }}
-          provenance: false
-          build-args: |
-            GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
-
-      - name: Retag for kind (image name the kustomize overlay points at)
-        run: |
-          # The prod overlay sets `newName: ghcr.io/openms/nuxl-app`,
-          # `newTag: main-full`. The rendered manifests reference that exact
-          # ref, so we need it loaded into kind under that name. Tag invariant
-          # across branches/variants so the test always works.
-          FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" ghcr.io/openms/nuxl-app:main-full
-
-      - name: Save image as tar
-        run: docker save ghcr.io/openms/nuxl-app:main-full -o /tmp/image.tar
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: openms-streamlit-${{ matrix.variant }}-arm64-image
-          path: /tmp/image.tar
-          retention-days: 1
-
-  create-manifest:
-    # Stitch the per-arch tags into multi-arch manifest lists. The manifest
-    # tags reuse the OLD scheme (`<ref>-<variant>`, `latest`) so existing
-    # consumers (k8s overlays, docker-compose users, `docker pull` callers)
-    # keep working transparently — docker now auto-selects the right arch
-    # on pull. PRs don't push per-arch tags, so there's nothing to merge.
-    needs: [build-amd64, build-arm64]
-    if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        variant: [full]
-    steps:
-      - name: Compute lowercase image name
-        run: echo "IMAGE_NAME_LC=${IMAGE_NAME,,}" >> "$GITHUB_ENV"
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute manifest tags
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # NB: no -amd64/-arm64 suffix here. These are the multi-arch
-          # manifest names; they must match the pre-arm64 tag scheme so
-          # `:main-full`, `:v1.0.0-full`, `:latest` continue to resolve.
-          tags: |
-            type=ref,event=branch,suffix=-${{ matrix.variant }}
-            type=ref,event=tag,suffix=-${{ matrix.variant }}
-            type=sha,prefix=,suffix=-${{ matrix.variant }}
-            type=raw,value=latest,enable=${{ matrix.variant == 'full' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-
-      - name: Create and push multi-arch manifests
-        # Iterate over manifest tags (newline-separated from metadata-action)
-        # and merge the matching `-amd64` / `-arm64` per-arch tags into each.
-        # `--amend` makes the step idempotent across workflow_dispatch reruns.
-        # `docker manifest push` accepts only one ref per invocation, hence
-        # the loop.
-        run: |
-          set -euo pipefail
-          while IFS= read -r manifest_tag; do
-            [ -z "$manifest_tag" ] && continue
-            amd_tag="${manifest_tag}-amd64"
-            arm_tag="${manifest_tag}-arm64"
-            echo "Creating manifest ${manifest_tag} from:"
-            echo "  amd: ${amd_tag}"
-            echo "  arm: ${arm_tag}"
-            docker manifest create "$manifest_tag" \
-              --amend "$amd_tag" \
-              --amend "$arm_tag"
-            docker manifest push "$manifest_tag"
-          done <<< "${{ steps.meta.outputs.tags }}"
 
   test-apptainer:
     # Apptainer/Singularity is the dominant container runtime on HPC clusters.
@@ -521,7 +364,7 @@ jobs:
           done <<< "${{ steps.meta.outputs.tags }}"
 
   test-nginx:
-    needs: [build-amd64, build-arm64]
+    needs: [build-amd64]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -530,9 +373,6 @@ jobs:
           - variant: full
             arch: amd64
             runner: ubuntu-latest
-          - variant: full
-            arch: arm64
-            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -650,7 +490,7 @@ jobs:
           kubectl logs -n ingress-nginx -l app.kubernetes.io/component=controller --tail=200 || true
 
   test-traefik:
-    needs: [build-amd64, build-arm64]
+    needs: [build-amd64]
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
@@ -659,9 +499,6 @@ jobs:
           - variant: full
             arch: amd64
             runner: ubuntu-latest
-          - variant: full
-            arch: arm64
-            runner: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -7,14 +7,14 @@ resources:
 components:
   - ../../components/memory-tier-low
 
-namePrefix: template-app-
+namePrefix: nuxl-app-
 
 commonLabels:
-  app: template-app
+  app: nuxl-app
 
 images:
   - name: openms-streamlit
-    newName: ghcr.io/openms/streamlit-template
+    newName: ghcr.io/openms/nuxl-app
     newTag: main-full
 
 patches:
@@ -24,21 +24,21 @@ patches:
     patch: |
       - op: replace
         path: /spec/routes/0/match
-        value: (Host(`template.webapps.openms.de`) || Host(`template.webapps.openms.org`)) && PathPrefix(`/`)
+        value: (Host(`nuxl.webapps.openms.de`) || Host(`nuxl.webapps.openms.org`)) && PathPrefix(`/`)
       - op: replace
         path: /spec/routes/0/services/0/name
-        value: template-app-streamlit
+        value: nuxl-app-streamlit
   - target:
       kind: Deployment
       name: streamlit
     patch: |
       - op: replace
         path: /spec/template/spec/containers/0/env/0/value
-        value: "redis://template-app-redis:6379/0"
+        value: "redis://nuxl-app-redis:6379/0"
   - target:
       kind: Deployment
       name: rq-worker
     patch: |
       - op: replace
         path: /spec/template/spec/containers/0/env/0/value
-        value: "redis://template-app-redis:6379/0"
+        value: "redis://nuxl-app-redis:6379/0"


### PR DESCRIPTION
## Kubernetes prod overlay (`k8s/overlays/prod/kustomization.yaml`)

Fills in the OpenMS prod Kustomize overlay with fork-specific values:

- `namePrefix` / `commonLabels.app`: `nuxl-app`
- image: `ghcr.io/openms/nuxl-app:main-full`
- Traefik `IngressRoute` hosts: `nuxl.webapps.openms.de` and `nuxl.webapps.openms.org`
- Redis URL (streamlit + rq-worker): `redis://nuxl-app-redis:6379/0`
- memory tier: `low`; workspace PVC left at the base default `500Gi`

## CI: amd64-only (`.github/workflows/build-and-test.yml`)

- Removed the `build-arm64` job (`Dockerfile.arm`, native ARM runner source build) and the now-redundant `create-manifest` job.
- `build-amd64` now publishes the canonical tags (`main-full`, `latest`, `<sha>-full`, `v*-full`) directly, instead of per-arch `-amd64` tags merged by `create-manifest`.
- `test-nginx` / `test-traefik` reduced to amd64-only.
- Retargeted the kind-test image retag/save from `ghcr.io/openms/streamlit-template:main-full` to `ghcr.io/openms/nuxl-app:main-full`, so the rendered overlay image matches what is loaded into kind (`imagePullPolicy: Never`).

**Effect:** amd64-only images (no multi-arch manifest); faster/cheaper CI. Drop the top commit (`ad8ace1`) if you'd rather land the k8s overlay alone.

## ⚠️ Deployment note

The overlay pulls `ghcr.io/openms/nuxl-app`, but CI publishes to `ghcr.io/<repo-owner>/nuxl-app` (derived from `github.repository`). For the cluster to pull successfully, the image must exist under the `openms` org — transfer the repo to `openms/nuxl-app`, or override `IMAGE_NAME` with GHCR write access to that org.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
