### PR TITLE
fix(k8s): enable HTTPS on traefik ingress; pull app image from arslan…

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -102,15 +102,15 @@ jobs:
 
       - name: Retag for kind (image name the kustomize overlay points at)
         run: |
-          # The prod overlay sets `newName: ghcr.io/openms/nuxl-app`,
+          # The prod overlay sets `newName: ghcr.io/arslan-siraj/nuxl-app`,
           # `newTag: main-full`. The rendered manifests reference that exact
           # ref, so we need it loaded into kind under that name. Tag invariant
           # across branches/variants so the test always works.
           FIRST_TAG=$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n 1)
-          docker tag "$FIRST_TAG" ghcr.io/openms/nuxl-app:main-full
+          docker tag "$FIRST_TAG" ghcr.io/arslan-siraj/nuxl-app:main-full
 
       - name: Save image as tar
-        run: docker save ghcr.io/openms/nuxl-app:main-full -o /tmp/image.tar
+        run: docker save ghcr.io/arslan-siraj/nuxl-app:main-full -o /tmp/image.tar
 
       - name: Upload image artifact
         uses: actions/upload-artifact@v4

--- a/k8s/base/traefik-ingressroute.yaml
+++ b/k8s/base/traefik-ingressroute.yaml
@@ -4,7 +4,8 @@ metadata:
   name: streamlit-traefik
 spec:
   entryPoints:
-    - web
+    - web          #  301-redirects to websecure
+    - websecure
   routes:
     - match: PathPrefix(`/`)
       kind: Rule
@@ -16,3 +17,4 @@ spec:
               name: stroute
               httpOnly: true
               sameSite: lax
+              secure: true   # only send the affinity cookie over HTTPS

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -14,7 +14,7 @@ commonLabels:
 
 images:
   - name: openms-streamlit
-    newName: ghcr.io/openms/nuxl-app
+    newName: ghcr.io/arslan-siraj/nuxl-app
     newTag: main-full
 
 patches:


### PR DESCRIPTION
…-siraj GHCR

Port the template's HTTPS fix: add the `websecure` entryPoint (so plain HTTP 301-redirects to HTTPS) and set `secure: true` on the sticky affinity cookie so it is only sent over HTTPS.

Repoint the prod overlay's app image to ghcr.io/arslan-siraj/nuxl-app, and keep the kind integration test's retag/save steps in sync with the overlay's newName so the image loads into kind under the referenced ref.


Claude-Session: https://claude.ai/code/session_018RgzVXtGqSxTy5UJRzeGUX